### PR TITLE
Contain uchiwa class

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = 'puppetlabs/ubuntu-14.04-64-puppet'
   config.vm.provision :shell, inline: 'apt-get update'
+  config.vm.provision :shell, inline: 'apt-get install puppet -y'
 
   config.vm.define 'derp1' do |c|
     c.vm.hostname = 'derp1'

--- a/puppet/modules/3am/manifests/uchiwa.pp
+++ b/puppet/modules/3am/manifests/uchiwa.pp
@@ -1,6 +1,6 @@
 class 3am::uchiwa {
 
-  include ::uchiwa
+  contain ::uchiwa
 
   sensu::check { 'check_uchiwa-health':
     command     => '/etc/sensu/plugins/plugins/uchiwa/uchiwa-health.rb',


### PR DESCRIPTION
Classes are not contained within other classes if not explicitly
contained with the anchor pattern or the contain keyword. This
causes the resource ordering to behave unpredictably even when
the three 3am classes are ordered. This commit contains the
uchiwa class within 3am::uchiwa. It also upgrades puppet in order
to support the contain keyword.
